### PR TITLE
Fix generator usage

### DIFF
--- a/scan_spring.py
+++ b/scan_spring.py
@@ -19,7 +19,7 @@ ZIP_EXTENSIONS = {".jar", ".war", ".sar", ".ear", ".par", ".zip", ".apk"}
 TAR_EXTENSIONS = {".tar.gz", ".tar"}
 
 ANNOTATION_STRS = {
-    b"annotation/RequestMapping;",
+    b"annotation/RequestMapping",
     b"annotation/GetMapping",
     b"annotation/PostMapping",
     b"annotation/PutMapping",
@@ -92,7 +92,7 @@ def examine_class(rel_path, file_name, content, silent_mode):
             print("Could not open class: %s" % file_name)
         return
 
-    annotation_constants = get_annotation_constants(cl)
+    annotation_constants = list(get_annotation_constants(cl))
 
     if not annotation_constants:
         return


### PR DESCRIPTION
During testing, we encountered a detection problem with the sample Spring application (https://www.journaldev.com/14476/spring-mvc-example). The scanner does not correctly detect multiple annotations in a single class file.

The problem is probably with the generator 'get_annotation_constants'.
Sending fix.

Best Regards
Michal.